### PR TITLE
Added list factory and mapDb

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,9 @@ dependencies {
     jmh group: 'org.apache.commons', name: 'commons-compress', version: 'latest.release'
     jmh 'org.openjdk.jmh:jmh-generator-annprocess:latest.release' // for IntelliJ
 
+    // https://mvnrepository.com/artifact/org.mapdb/mapdb
+    compile group: 'org.mapdb', name: 'mapdb', version: '3.0.8'
+
     components.all { ComponentMetadataDetails details ->
         details.statusScheme = ['candidate', 'release']
         if (details.id.version =~ /(?i).+([-.])(CANDIDATE|RC|BETA|ALPHA).*/) {
@@ -163,8 +166,4 @@ dependencies {
             details.status = 'release'
         }
     }
-}
-
-dependencyLocking {
-    lockAllConfigurations()
 }

--- a/src/jmh/java/de/bwaldvogel/liblinear/LinearBenchmark.java
+++ b/src/jmh/java/de/bwaldvogel/liblinear/LinearBenchmark.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
@@ -31,16 +32,18 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
 public class LinearBenchmark {
 
+    private static Class clazz = ArrayList.class;
+
     @Benchmark
     public void readProblem(DatasetParameters datasetParameters) throws Exception {
         Path trainingFile = getTrainingFile(datasetParameters.dataset);
         try (InputStream inputStream = getInputStream(trainingFile)) {
-            Train.readProblem(inputStream, -1);
+            Train.readProblem(clazz, inputStream, -1);
         }
     }
 
     @Benchmark
-    public void train(BenchmarkParameters benchmarkParameters) {
+    public void train(BenchmarkParameters benchmarkParameters) throws IllegalAccessException, InstantiationException {
         Linear.disableDebugOutput();
         Linear.train(benchmarkParameters.problem, new Parameter(benchmarkParameters.solverType, 1, 1e-3));
     }
@@ -65,7 +68,7 @@ public class LinearBenchmark {
         public void loadDataset() throws Exception {
             Path trainingFile = getTrainingFile(dataset);
             try (InputStream inputStream = getInputStream(trainingFile)) {
-                problem = Train.readProblem(inputStream, -1);
+                problem = Train.readProblem(clazz, inputStream, -1);
             }
         }
 

--- a/src/jmh/java/de/bwaldvogel/liblinear/LinearBenchmark.java
+++ b/src/jmh/java/de/bwaldvogel/liblinear/LinearBenchmark.java
@@ -32,13 +32,11 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
 public class LinearBenchmark {
 
-    private static Class clazz = ArrayList.class;
-
     @Benchmark
     public void readProblem(DatasetParameters datasetParameters) throws Exception {
         Path trainingFile = getTrainingFile(datasetParameters.dataset);
         try (InputStream inputStream = getInputStream(trainingFile)) {
-            Train.readProblem(clazz, inputStream, -1);
+            Train.readProblem(new MemoryListFactory(), inputStream, -1);
         }
     }
 
@@ -68,7 +66,7 @@ public class LinearBenchmark {
         public void loadDataset() throws Exception {
             Path trainingFile = getTrainingFile(dataset);
             try (InputStream inputStream = getInputStream(trainingFile)) {
-                problem = Train.readProblem(clazz, inputStream, -1);
+                problem = Train.readProblem(new MemoryListFactory(), inputStream, -1);
             }
         }
 

--- a/src/main/java/de/bwaldvogel/liblinear/Feature.java
+++ b/src/main/java/de/bwaldvogel/liblinear/Feature.java
@@ -1,9 +1,11 @@
 package de.bwaldvogel.liblinear;
 
+import java.io.Serializable;
+
 /**
  * @since 1.9
  */
-public interface Feature {
+public interface Feature extends Serializable {
 
     int getIndex();
 

--- a/src/main/java/de/bwaldvogel/liblinear/FeatureVector.java
+++ b/src/main/java/de/bwaldvogel/liblinear/FeatureVector.java
@@ -1,0 +1,17 @@
+package de.bwaldvogel.liblinear;
+
+/**
+ * TODO: add javadoc.
+ */
+
+public class FeatureVector {
+    public Feature[] getFeatures() {
+        return features;
+    }
+
+    private final Feature[] features;
+    public FeatureVector(Feature[] features){
+        this.features = features;
+    }
+
+}

--- a/src/main/java/de/bwaldvogel/liblinear/FeatureVector.java
+++ b/src/main/java/de/bwaldvogel/liblinear/FeatureVector.java
@@ -1,16 +1,19 @@
 package de.bwaldvogel.liblinear;
 
+import java.io.Serializable;
+
 /**
- * TODO: add javadoc.
+ * Wrapper around feature array.
  */
 
-public class FeatureVector {
+public class FeatureVector implements Serializable {
     public Feature[] getFeatures() {
         return features;
     }
 
     private final Feature[] features;
-    public FeatureVector(Feature[] features){
+
+    public FeatureVector(Feature[] features) {
         this.features = features;
     }
 

--- a/src/main/java/de/bwaldvogel/liblinear/L2R_ErmFunction.java
+++ b/src/main/java/de/bwaldvogel/liblinear/L2R_ErmFunction.java
@@ -12,7 +12,7 @@ abstract class L2R_ErmFunction implements Function {
     final   boolean regularize_bias;
 
     L2R_ErmFunction(Problem prob, Parameter parameter, double[] C) {
-        int l = prob.l;
+        int l = prob.getL();
 
         this.prob = prob;
 
@@ -24,23 +24,21 @@ abstract class L2R_ErmFunction implements Function {
 
     void Xv(double[] v, double[] Xv) {
         int i;
-        int l = prob.l;
-        Feature[][] x = prob.x;
+        int l = prob.getL();
 
         for (i = 0; i < l; i++)
-            Xv[i] = SparseOperator.dot(v, x[i]);
+            Xv[i] = SparseOperator.dot(v, prob.getX(i));
     }
 
     void XTv(double[] v, double[] XTv) {
-        int l = prob.l;
+        int l = prob.getL();
         int w_size = get_nr_variable();
-        Feature[][] x = prob.x;
 
         for (int i = 0; i < w_size; i++)
             XTv[i] = 0;
 
         for (int i = 0; i < l; i++) {
-            SparseOperator.axpy(v[i], x[i], XTv);
+            SparseOperator.axpy(v[i], prob.getX(i), XTv);
         }
     }
 
@@ -50,7 +48,7 @@ abstract class L2R_ErmFunction implements Function {
     public double fun(double[] w) {
         int i;
         double f = 0;
-        int l = prob.l;
+        int l = prob.getL();
         int w_size = get_nr_variable();
 
         wTw = 0;
@@ -77,7 +75,7 @@ abstract class L2R_ErmFunction implements Function {
     @Override
     public double linesearch_and_update(double[] w, double[] s, MutableDouble f, double[] g, double alpha) {
         int i;
-        int l = prob.l;
+        int l = prob.getL();
         double sTs = 0;
         double wTs = 0;
         double gTs = 0;

--- a/src/main/java/de/bwaldvogel/liblinear/L2R_L2_SvcFunction.java
+++ b/src/main/java/de/bwaldvogel/liblinear/L2R_L2_SvcFunction.java
@@ -7,7 +7,7 @@ class L2R_L2_SvcFunction extends L2R_ErmFunction {
 
     public L2R_L2_SvcFunction(Problem prob, Parameter param, double[] C) {
         super(prob, param, C);
-        I = new int[prob.l];
+        I = new int[prob.getL()];
     }
 
     @Override
@@ -23,7 +23,7 @@ class L2R_L2_SvcFunction extends L2R_ErmFunction {
     public void grad(double[] w, double[] g) {
         int i;
         double[] y = prob.y;
-        int l = prob.l;
+        int l = prob.getL();
         int w_size = get_nr_variable();
 
         sizeI = 0;
@@ -46,7 +46,6 @@ class L2R_L2_SvcFunction extends L2R_ErmFunction {
     @Override
     public void get_diag_preconditioner(double[] M) {
         int w_size = get_nr_variable();
-        Feature[][] x = prob.x;
 
         for (int i = 0; i < w_size; i++)
             M[i] = 1;
@@ -55,7 +54,7 @@ class L2R_L2_SvcFunction extends L2R_ErmFunction {
 
         for (int i = 0; i < sizeI; i++) {
             int idx = I[i];
-            for (Feature s : x[idx]) {
+            for (Feature s : prob.getX(idx)) {
                 M[s.getIndex() - 1] += s.getValue() * s.getValue() * C[idx] * 2;
             }
         }
@@ -65,12 +64,11 @@ class L2R_L2_SvcFunction extends L2R_ErmFunction {
     public void Hv(double[] s, double[] Hs) {
         int i;
         int w_size = get_nr_variable();
-        Feature[][] x = prob.x;
 
         for (i = 0; i < w_size; i++)
             Hs[i] = 0;
         for (i = 0; i < sizeI; i++) {
-            Feature[] xi = x[I[i]];
+            Feature[] xi = prob.getX(I[i]);
             double xTs = SparseOperator.dot(s, xi);
             xTs = C[I[i]] * xTs;
 
@@ -85,12 +83,11 @@ class L2R_L2_SvcFunction extends L2R_ErmFunction {
     protected void subXTv(double[] v, double[] XTv) {
         int i;
         int w_size = get_nr_variable();
-        Feature[][] x = prob.x;
 
         for (i = 0; i < w_size; i++)
             XTv[i] = 0;
         for (i = 0; i < sizeI; i++)
-            SparseOperator.axpy(v[i], x[I[i]], XTv);
+            SparseOperator.axpy(v[i], prob.getX(I[i]), XTv);
     }
 
 }

--- a/src/main/java/de/bwaldvogel/liblinear/L2R_L2_SvrFunction.java
+++ b/src/main/java/de/bwaldvogel/liblinear/L2R_L2_SvrFunction.java
@@ -26,7 +26,7 @@ public class L2R_L2_SvrFunction extends L2R_L2_SvcFunction {
     public void grad(double[] w, double[] g) {
         int i;
         double[] y = prob.y;
-        int l = prob.l;
+        int l = prob.getL();
         int w_size = get_nr_variable();
         double d;
 

--- a/src/main/java/de/bwaldvogel/liblinear/L2R_LrFunction.java
+++ b/src/main/java/de/bwaldvogel/liblinear/L2R_LrFunction.java
@@ -6,7 +6,7 @@ class L2R_LrFunction extends L2R_ErmFunction {
 
     L2R_LrFunction(Problem prob, Parameter param, double[] C) {
         super(prob, param, C);
-        int l = prob.l;
+        int l = prob.getL();
         D = new double[l];
     }
 
@@ -23,7 +23,7 @@ class L2R_LrFunction extends L2R_ErmFunction {
     public void grad(double[] w, double[] g) {
         int i;
         double[] y = prob.y;
-        int l = prob.l;
+        int l = prob.getL();
         int w_size = get_nr_variable();
 
         for (i = 0; i < l; i++) {
@@ -41,9 +41,8 @@ class L2R_LrFunction extends L2R_ErmFunction {
 
     @Override
     public void get_diag_preconditioner(double[] M) {
-        int l = prob.l;
+        int l = prob.getL();
         int w_size = get_nr_variable();
-        Feature[][] x = prob.x;
 
         for (int i = 0; i < w_size; i++)
             M[i] = 1;
@@ -51,7 +50,7 @@ class L2R_LrFunction extends L2R_ErmFunction {
             M[w_size - 1] = 0;
 
         for (int i = 0; i < l; i++) {
-            for (Feature xi : x[i]) {
+            for (Feature xi : prob.getX(i)) {
                 M[xi.getIndex() - 1] += xi.getValue() * xi.getValue() * C[i] * D[i];
             }
         }
@@ -60,14 +59,13 @@ class L2R_LrFunction extends L2R_ErmFunction {
     @Override
     public void Hv(double[] s, double[] Hs) {
         int i;
-        int l = prob.l;
+        int l = prob.getL();
         int w_size = get_nr_variable();
-        Feature[][] x = prob.x;
 
         for (i = 0; i < w_size; i++)
             Hs[i] = 0;
         for (i = 0; i < l; i++) {
-            Feature[] xi = x[i];
+            Feature[] xi = prob.getX(i);
             double xTs = SparseOperator.dot(s, xi);
 
             xTs = C[i] * D[i] * xTs;

--- a/src/main/java/de/bwaldvogel/liblinear/Linear.java
+++ b/src/main/java/de/bwaldvogel/liblinear/Linear.java
@@ -77,7 +77,7 @@ public class Linear {
             int begin = fold_start[i];
             int end = fold_start[i + 1];
             int j, k;
-            Problem subprob = new Problem(prob.getClazz(), prob.getSize());
+            Problem subprob = new Problem(prob.getListFactory(), prob.getSize());
 
             subprob.bias = prob.bias;
             subprob.n = prob.n;
@@ -102,8 +102,7 @@ public class Linear {
         }
     }
 
-    public static ParameterSearchResult findParameters(Class<? extends ArrayList<FeatureVector>> clazz,
-                                                       Problem<?extends ArrayList<FeatureVector>> prob,
+    public static ParameterSearchResult findParameters(Problem<? extends ListFactory> prob,
                                                        Parameter param, int nr_fold, double start_C, double start_p)
           throws InstantiationException, IllegalAccessException {
         double best_C = Double.NaN;
@@ -134,7 +133,7 @@ public class Linear {
             int j, k;
 
             assert subprob[i] == null;
-            subprob[i] = new Problem<>(clazz, l - (end - begin));
+            subprob[i] = new Problem<>(prob.getListFactory(), l - (end - begin));
             subprob[i].bias = prob.bias;
             subprob[i].n = prob.n;
             subprob[i].setL(l - (end - begin));
@@ -1994,7 +1993,7 @@ public class Linear {
         int l = prob.getL();
         int n = prob.n;
         int[] col_ptr = new int[n + 1];
-        Problem prob_col = new Problem(prob.getClazz(),n);
+        Problem prob_col = new Problem(prob.getListFactory(),n);
        // prob_col.l = l;
         prob_col.n = n;
         prob_col.y = new double[l];
@@ -2056,7 +2055,7 @@ public class Linear {
     /**
      * @throws IllegalArgumentException if the feature nodes of prob are not sorted in ascending order
      */
-    public static Model train(Problem<? extends ArrayList<FeatureVector>> prob, Parameter param)
+    public static Model train(Problem<? extends ListFactory> prob, Parameter param)
           throws InstantiationException, IllegalAccessException {
         if (prob == null) {
             throw new IllegalArgumentException("problem must not be null");
@@ -2187,7 +2186,7 @@ public class Linear {
             for ( i = 0; i < l; i++)
                 x[i] = prob.getX(perm[i]);
 
-            Problem<? extends ArrayList<FeatureVector>> sub_prob = new Problem<>(prob.getClazz(), prob.getSize());
+            Problem<? extends ListFactory> sub_prob = new Problem<>(prob.getListFactory(), prob.getSize());
             sub_prob.n = n;
             sub_prob.setL(l);
             sub_prob.y = new double[sub_prob.getL()];
@@ -2268,7 +2267,7 @@ public class Linear {
         }
     }
 
-    private static void train_one(Problem<? extends ArrayList<FeatureVector>> prob,
+    private static void train_one(Problem<? extends ListFactory> prob,
                                   Parameter param, double[] w, double Cp, double Cn)
           throws IllegalAccessException, InstantiationException {
         SolverType solver_type = param.solverType;
@@ -2327,12 +2326,12 @@ public class Linear {
                 break;
             }
             case L1R_L2LOSS_SVC: {
-                Problem<? extends ArrayList<FeatureVector>> prob_col = transpose(prob);
+                Problem<? extends ListFactory> prob_col = transpose(prob);
                 solve_l1r_l2_svc(prob_col, param, w, Cp, Cn, primal_solver_tol, param.max_iters);
                 break;
             }
             case L1R_LR: {
-                Problem<? extends ArrayList<FeatureVector>> prob_col = transpose(prob);
+                Problem<? extends ListFactory> prob_col = transpose(prob);
                 solve_l1r_lr(prob_col, param, w, Cp, Cn, primal_solver_tol, param.max_iters);
                 break;
             }
@@ -2424,7 +2423,7 @@ public class Linear {
         return max_p;
     }
 
-    public static ParameterCSearchResult find_parameter_C(Problem<? extends ArrayList<FeatureVector>> prob,
+    public static ParameterCSearchResult find_parameter_C(Problem<? extends ListFactory> prob,
                                                           Parameter param_tmp, double start_C, double max_C, int[] fold_start, int[] perm,
         Problem[] subprob, int nr_fold) throws IllegalAccessException, InstantiationException {
         double best_C;

--- a/src/main/java/de/bwaldvogel/liblinear/ListFactory.java
+++ b/src/main/java/de/bwaldvogel/liblinear/ListFactory.java
@@ -1,0 +1,12 @@
+package de.bwaldvogel.liblinear;
+
+import java.util.ArrayList;
+
+/**
+ * Abstract class for wrapping around an arraylist.
+ */
+
+public abstract class ListFactory implements AutoCloseable {
+
+    public abstract ArrayList<FeatureVector> createList(int size);
+}

--- a/src/main/java/de/bwaldvogel/liblinear/MapDbFileListFactory.java
+++ b/src/main/java/de/bwaldvogel/liblinear/MapDbFileListFactory.java
@@ -1,0 +1,70 @@
+package de.bwaldvogel.liblinear;
+
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+import org.mapdb.DB;
+import org.mapdb.DBMaker;
+import org.mapdb.IndexTreeList;
+import org.mapdb.Serializer;
+
+/**
+ * A MapDb backed list factory which writes to a temporary file.
+ */
+
+public class MapDbFileListFactory extends ListFactory {
+
+    List<String> generatedFiles = Lists.newArrayList();
+
+    @Override
+    public ArrayList<FeatureVector> createList(int size) {
+        String listId = UUID.randomUUID().toString();
+        String tempFile = "/tmp/" + listId + ".db";
+        generatedFiles.add(tempFile);
+        DB db = DBMaker.fileDB(tempFile).make();
+        return new IndexTreeListWrapper(
+              (IndexTreeList<FeatureVector>) db.indexTreeList(listId, Serializer.JAVA).createOrOpen());
+
+    }
+
+    @Override
+    public void close() throws IOException {
+        for (String file : generatedFiles) {
+            Files.deleteIfExists(Paths.get(file));
+        }
+    }
+
+    public static class IndexTreeListWrapper extends ArrayList<FeatureVector> {
+
+        private final IndexTreeList<FeatureVector> indexTreeList;
+
+        public IndexTreeListWrapper(IndexTreeList<FeatureVector> indexTreeList) {
+            this.indexTreeList = indexTreeList;
+        }
+
+        public FeatureVector set(int index, FeatureVector element) {
+            return indexTreeList.set(index, element);
+        }
+
+        public FeatureVector get(int index) {
+            return indexTreeList.get(index);
+        }
+
+        public boolean add(FeatureVector element) {
+            return indexTreeList.add(element);
+        }
+
+        public int size() {
+            return indexTreeList.size();
+        }
+
+        public Iterator<FeatureVector> iterator() {
+            return indexTreeList.iterator();
+        }
+    }
+}

--- a/src/main/java/de/bwaldvogel/liblinear/MapDbOffHeapListFactory.java
+++ b/src/main/java/de/bwaldvogel/liblinear/MapDbOffHeapListFactory.java
@@ -1,0 +1,32 @@
+package de.bwaldvogel.liblinear;
+
+import de.bwaldvogel.liblinear.MapDbFileListFactory.IndexTreeListWrapper;
+import java.util.ArrayList;
+import java.util.UUID;
+import org.mapdb.DB;
+import org.mapdb.DBMaker;
+import org.mapdb.IndexTreeList;
+import org.mapdb.Serializer;
+
+/**
+ * A MapDb backed list factory which writes to a off-heap memory.
+ */
+
+public class MapDbOffHeapListFactory extends ListFactory {
+
+    @Override
+    public ArrayList<FeatureVector> createList(int size) {
+        String listId = UUID.randomUUID().toString();
+        DB db = DBMaker.memoryDirectDB().make();
+        return new IndexTreeListWrapper(
+              (IndexTreeList<FeatureVector>) db.indexTreeList(listId, Serializer.JAVA).createOrOpen());
+
+    }
+
+    @Override
+    public void close() {
+        //NOOP
+    }
+
+
+}

--- a/src/main/java/de/bwaldvogel/liblinear/MemoryListFactory.java
+++ b/src/main/java/de/bwaldvogel/liblinear/MemoryListFactory.java
@@ -1,0 +1,20 @@
+package de.bwaldvogel.liblinear;
+
+import java.util.ArrayList;
+
+/**
+ * A list-factory which produces in-memory lists.
+ */
+
+public class MemoryListFactory extends ListFactory {
+    @Override
+    public ArrayList<FeatureVector> createList(int size) {
+        return new ArrayList<>(size);
+    }
+
+    @Override
+    public void close() {
+        //NOOP
+    }
+
+}

--- a/src/main/java/de/bwaldvogel/liblinear/Problem.java
+++ b/src/main/java/de/bwaldvogel/liblinear/Problem.java
@@ -36,126 +36,141 @@ import java.util.Iterator;
  *       [ ] -&gt; (1,-0.1) (2,-0.2) (3,0.1) (4,1.1) (5,0.1) (6,1) (-1,?)
  * </pre>
  */
-public class Problem<T extends ArrayList<FeatureVector>> {
+public class Problem<T extends ListFactory> implements AutoCloseable {
 
-    /** the number of training data */
+    /**
+     * the number of training data
+     */
     private int l;
 
-    /** the number of features (including the bias feature if bias &gt;= 0) */
+    /**
+     * the number of features (including the bias feature if bias &gt;= 0)
+     */
     public int n;
 
     private int size;
 
-    /** an array containing the target values */
+    /**
+     * an array containing the target values
+     */
     public double[] y;
 
-    /** array of sparse feature nodes */
-    public T x;
+    /**
+     * array of sparse feature nodes
+     */
+    public ArrayList<FeatureVector> x;
 
-    public Class<T> getClazz() {
-        return clazz;
-    }
+    private T listFactory;
 
-    public Class<T> clazz;
-
-    public Problem(Class<T> listclazz, int size) throws IllegalAccessException, InstantiationException {
-        x = listclazz.newInstance();
-        for (int i =0;i<size;i++){
+    public Problem(T listFactory, int size) {
+        this.listFactory = listFactory;
+        x = listFactory.createList(size);
+        for (int i = 0; i < size; i++) {
             x.add(null);
         }
-        this.clazz =listclazz;
         this.size = size;
     }
 
-    public void reinitX(int size) throws IllegalAccessException, InstantiationException {
-        x = clazz.newInstance();
-        for (int i =0;i<size;i++){
+    public void reinitX(int size) {
+        x = listFactory.createList(size);
+        for (int i = 0; i < size; i++) {
             x.add(null);
         }
     }
 
-    public void setL(int l){
+    public void setL(int l) {
         this.l = l;
     }
-    public int getL(){
+
+    public int getL() {
         return l;
     }
 
-    public int getSize(){
+    public ListFactory getListFactory() {
+        return listFactory;
+    }
+
+    public int getSize() {
         return size;
     }
-    public void setX(int index, Feature[] features){
+
+    public void setX(int index, Feature[] features) {
         x.set(index, new FeatureVector(features));
     }
 
-    public Feature[] getX(int index){
+    public Feature[] getX(int index) {
         return x.get(index).getFeatures();
     }
 
-    public Iterator<FeatureVector> getXIterator(){
+    public Iterator<FeatureVector> getXIterator() {
         return x.iterator();
     }
+
     /**
-     * If bias &gt;= 0, we assume that one additional feature is added
-     * to the end of each data instance
+     * If bias &gt;= 0, we assume that one additional feature is added to the end of each data instance
      */
     public double bias = -1;
 
     /**
      * @deprecated use {@link Problem#readFromFile(Path, double)} instead
      */
-    public static Problem readFromFile(Class<? extends ArrayList<FeatureVector>> clazz,
+    public static Problem readFromFile(ListFactory listFactory,
                                        File file, double bias) throws IOException,
           InvalidInputDataException, IllegalAccessException, InstantiationException {
-        return readFromFile(clazz, file.toPath(), bias);
+        return readFromFile(listFactory, file.toPath(), bias);
     }
 
     /**
      * see {@link Train#readProblem(Path, double)}
      */
-    public static Problem readFromFile(Class<? extends ArrayList<FeatureVector>> clazz,
+    public static Problem readFromFile(ListFactory listFactory,
                                        Path path, double bias)
           throws IOException, InvalidInputDataException, InstantiationException, IllegalAccessException {
-        return Train.readProblem(clazz, path, bias);
+        return Train.readProblem(listFactory, path, bias);
     }
 
     /**
      * @deprecated use {@link Problem#readFromFile(Path, Charset, double)} instead
      */
-    public static Problem readFromFile(Class<? extends ArrayList<FeatureVector>> clazz,
+    public static Problem readFromFile(ListFactory listFactory,
                                        File file, Charset charset,
                                        double bias)
           throws IOException, InvalidInputDataException, InstantiationException, IllegalAccessException {
-        return readFromFile(clazz, file.toPath(), charset, bias);
+        return readFromFile(listFactory, file.toPath(), charset, bias);
     }
 
     /**
      * see {@link Train#readProblem(Path, Charset, double)}
      */
-    public static Problem readFromFile(Class<? extends ArrayList<FeatureVector>> clazz,
+    public static Problem readFromFile(ListFactory listFactory,
                                        Path path, Charset charset,
                                        double bias)
           throws IOException, InvalidInputDataException, IllegalAccessException, InstantiationException {
-        return Train.readProblem(clazz, path, charset, bias);
+        return Train.readProblem(listFactory, path, charset, bias);
     }
 
     /**
      * see {@link Train#readProblem(InputStream, double)}
      */
-    public static Problem readFromStream(Class<? extends ArrayList<FeatureVector>> clazz,
+    public static Problem readFromStream(ListFactory listFactory,
                                          InputStream inputStream,
                                          double bias)
           throws IOException, InvalidInputDataException, IllegalAccessException, InstantiationException {
-        return Train.readProblem(clazz, inputStream, bias);
+        return Train.readProblem(listFactory, inputStream, bias);
     }
 
     /**
      * see {@link Train#readProblem(InputStream, Charset, double)}
      */
-    public static Problem readFromStream(Class<? extends ArrayList<FeatureVector>> clazz,
+    public static Problem readFromStream(ListFactory listFactory,
                                          InputStream inputStream,
                                          Charset charset, double bias)
           throws IOException, InvalidInputDataException, InstantiationException, IllegalAccessException {
-        return Train.readProblem(clazz, inputStream, charset, bias);
+        return Train.readProblem(listFactory, inputStream, charset, bias);
+    }
+
+    @Override
+    public void close() throws Exception {
+        listFactory.close();
     }
 }

--- a/src/main/java/de/bwaldvogel/liblinear/Problem.java
+++ b/src/main/java/de/bwaldvogel/liblinear/Problem.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
 
 
 /**
@@ -34,20 +36,65 @@ import java.nio.file.Path;
  *       [ ] -&gt; (1,-0.1) (2,-0.2) (3,0.1) (4,1.1) (5,0.1) (6,1) (-1,?)
  * </pre>
  */
-public class Problem {
+public class Problem<T extends ArrayList<FeatureVector>> {
 
     /** the number of training data */
-    public int l;
+    private int l;
 
     /** the number of features (including the bias feature if bias &gt;= 0) */
     public int n;
+
+    private int size;
 
     /** an array containing the target values */
     public double[] y;
 
     /** array of sparse feature nodes */
-    public Feature[][] x;
+    public T x;
 
+    public Class<T> getClazz() {
+        return clazz;
+    }
+
+    public Class<T> clazz;
+
+    public Problem(Class<T> listclazz, int size) throws IllegalAccessException, InstantiationException {
+        x = listclazz.newInstance();
+        for (int i =0;i<size;i++){
+            x.add(null);
+        }
+        this.clazz =listclazz;
+        this.size = size;
+    }
+
+    public void reinitX(int size) throws IllegalAccessException, InstantiationException {
+        x = clazz.newInstance();
+        for (int i =0;i<size;i++){
+            x.add(null);
+        }
+    }
+
+    public void setL(int l){
+        this.l = l;
+    }
+    public int getL(){
+        return l;
+    }
+
+    public int getSize(){
+        return size;
+    }
+    public void setX(int index, Feature[] features){
+        x.set(index, new FeatureVector(features));
+    }
+
+    public Feature[] getX(int index){
+        return x.get(index).getFeatures();
+    }
+
+    public Iterator<FeatureVector> getXIterator(){
+        return x.iterator();
+    }
     /**
      * If bias &gt;= 0, we assume that one additional feature is added
      * to the end of each data instance
@@ -57,42 +104,58 @@ public class Problem {
     /**
      * @deprecated use {@link Problem#readFromFile(Path, double)} instead
      */
-    public static Problem readFromFile(File file, double bias) throws IOException, InvalidInputDataException {
-        return readFromFile(file.toPath(), bias);
+    public static Problem readFromFile(Class<? extends ArrayList<FeatureVector>> clazz,
+                                       File file, double bias) throws IOException,
+          InvalidInputDataException, IllegalAccessException, InstantiationException {
+        return readFromFile(clazz, file.toPath(), bias);
     }
 
     /**
      * see {@link Train#readProblem(Path, double)}
      */
-    public static Problem readFromFile(Path path, double bias) throws IOException, InvalidInputDataException {
-        return Train.readProblem(path, bias);
+    public static Problem readFromFile(Class<? extends ArrayList<FeatureVector>> clazz,
+                                       Path path, double bias)
+          throws IOException, InvalidInputDataException, InstantiationException, IllegalAccessException {
+        return Train.readProblem(clazz, path, bias);
     }
 
     /**
      * @deprecated use {@link Problem#readFromFile(Path, Charset, double)} instead
      */
-    public static Problem readFromFile(File file, Charset charset, double bias) throws IOException, InvalidInputDataException {
-        return readFromFile(file.toPath(), charset, bias);
+    public static Problem readFromFile(Class<? extends ArrayList<FeatureVector>> clazz,
+                                       File file, Charset charset,
+                                       double bias)
+          throws IOException, InvalidInputDataException, InstantiationException, IllegalAccessException {
+        return readFromFile(clazz, file.toPath(), charset, bias);
     }
 
     /**
      * see {@link Train#readProblem(Path, Charset, double)}
      */
-    public static Problem readFromFile(Path path, Charset charset, double bias) throws IOException, InvalidInputDataException {
-        return Train.readProblem(path, charset, bias);
+    public static Problem readFromFile(Class<? extends ArrayList<FeatureVector>> clazz,
+                                       Path path, Charset charset,
+                                       double bias)
+          throws IOException, InvalidInputDataException, IllegalAccessException, InstantiationException {
+        return Train.readProblem(clazz, path, charset, bias);
     }
 
     /**
      * see {@link Train#readProblem(InputStream, double)}
      */
-    public static Problem readFromStream(InputStream inputStream, double bias) throws IOException, InvalidInputDataException {
-        return Train.readProblem(inputStream, bias);
+    public static Problem readFromStream(Class<? extends ArrayList<FeatureVector>> clazz,
+                                         InputStream inputStream,
+                                         double bias)
+          throws IOException, InvalidInputDataException, IllegalAccessException, InstantiationException {
+        return Train.readProblem(clazz, inputStream, bias);
     }
 
     /**
      * see {@link Train#readProblem(InputStream, Charset, double)}
      */
-    public static Problem readFromStream(InputStream inputStream, Charset charset, double bias) throws IOException, InvalidInputDataException {
-        return Train.readProblem(inputStream, charset, bias);
+    public static Problem readFromStream(Class<? extends ArrayList<FeatureVector>> clazz,
+                                         InputStream inputStream,
+                                         Charset charset, double bias)
+          throws IOException, InvalidInputDataException, InstantiationException, IllegalAccessException {
+        return Train.readProblem(clazz, inputStream, charset, bias);
     }
 }

--- a/src/main/java/de/bwaldvogel/liblinear/SolverMCSVM_CS.java
+++ b/src/main/java/de/bwaldvogel/liblinear/SolverMCSVM_CS.java
@@ -49,7 +49,7 @@ class SolverMCSVM_CS {
 
     public SolverMCSVM_CS(Problem prob, int nr_class, double[] weighted_C, double eps, int max_iter) {
         this.w_size = prob.n;
-        this.l = prob.l;
+        this.l = prob.getL();
         this.nr_class = nr_class;
         this.eps = eps;
         this.max_iter = max_iter;
@@ -102,7 +102,7 @@ class SolverMCSVM_CS {
             for (m = 0; m < nr_class; m++)
                 alpha_index[i * nr_class + m] = m;
             QD[i] = 0;
-            for (Feature xi : prob.x[i]) {
+            for (Feature xi : prob.getX(i)) {
                 double val = xi.getValue();
                 QD[i] += val * val;
 
@@ -142,7 +142,7 @@ class SolverMCSVM_CS {
                     if (y_index[i] < active_size_i[i])
                         G[y_index[i]] = 0;
 
-                    for (Feature xi : prob.x[i]) {
+                    for (Feature xi : prob.getX(i)) {
                         // double *w_i = &w[(xi.index-1)*nr_class];
                         int w_offset = (xi.getIndex() - 1) * nr_class;
                         for (m = 0; m < active_size_i[i]; m++)
@@ -210,7 +210,7 @@ class SolverMCSVM_CS {
                         }
                     }
 
-                    for (Feature xi : prob.x[i]) {
+                    for (Feature xi : prob.getX(i)) {
                         // double *w_i = &w[(xi->index-1)*nr_class];
                         int w_offset = (xi.getIndex() - 1) * nr_class;
                         for (m = 0; m < nz_d; m++) {

--- a/src/main/java/de/bwaldvogel/liblinear/Train.java
+++ b/src/main/java/de/bwaldvogel/liblinear/Train.java
@@ -20,9 +20,12 @@ import java.util.StringTokenizer;
 
 public class Train {
 
-    public static void main(String[] args) throws IOException, InvalidInputDataException {
+    public static void main(String[] args)
+          throws IOException, InvalidInputDataException, IllegalAccessException, InstantiationException {
         new Train().run(args);
     }
+
+    Class clazz = ArrayList.class;
 
     private double    bias             = 1;
     private boolean   find_parameters  = false;
@@ -36,7 +39,7 @@ public class Train {
     private Parameter param            = null;
     private Problem   prob             = null;
 
-    private void do_find_parameters() {
+    private void do_find_parameters() throws IllegalAccessException, InstantiationException {
         double start_C, start_p;
         if (C_specified)
             start_C = param.C;
@@ -48,18 +51,18 @@ public class Train {
             start_p = -1.0;
 
         System.out.printf("Doing parameter search with %d-fold cross validation.%n", nr_fold);
-        ParameterSearchResult result = Linear.findParameters(prob, param, nr_fold, start_C, start_p);
+        ParameterSearchResult result = Linear.findParameters(clazz, prob, param, nr_fold, start_C, start_p);
         if (param.getSolverType() == L2R_LR || param.getSolverType() == L2R_L2LOSS_SVC)
             System.out.printf("Best C = %g  CV accuracy = %g%%\n", result.getBestC(), 100.0 * result.getBestScore());
         else if (param.getSolverType() == L2R_L2LOSS_SVR)
             System.out.printf("Best C = %g Best p = %g  CV MSE = %g\n", result.getBestC(), result.getBestP(), result.getBestScore());
     }
 
-    private void do_cross_validation() {
+    private void do_cross_validation() throws IllegalAccessException, InstantiationException {
 
         double total_error = 0;
         double sumv = 0, sumy = 0, sumvv = 0, sumyy = 0, sumvy = 0;
-        double[] target = new double[prob.l];
+        double[] target = new double[prob.getL()];
 
         long start, stop;
         start = System.currentTimeMillis();
@@ -68,7 +71,7 @@ public class Train {
         System.out.println("time: " + (stop - start) + " ms");
 
         if (param.solverType.isSupportVectorRegression()) {
-            for (int i = 0; i < prob.l; i++) {
+            for (int i = 0; i < prob.getL(); i++) {
                 double y = prob.y[i];
                 double v = target[i];
                 total_error += (v - y) * (v - y);
@@ -78,17 +81,17 @@ public class Train {
                 sumyy += y * y;
                 sumvy += v * y;
             }
-            System.out.printf("Cross Validation Mean squared error = %g%n", total_error / prob.l);
+            System.out.printf("Cross Validation Mean squared error = %g%n", total_error / prob.getL());
             System.out.printf("Cross Validation Squared correlation coefficient = %g%n", //
-                ((prob.l * sumvy - sumv * sumy) * (prob.l * sumvy - sumv * sumy)) / ((prob.l * sumvv - sumv * sumv) * (prob.l * sumyy - sumy * sumy)));
+                ((prob.getL() * sumvy - sumv * sumy) * (prob.getL() * sumvy - sumv * sumy)) / ((prob.getL() * sumvv - sumv * sumv) * (prob.getL() * sumyy - sumy * sumy)));
         } else {
             int total_correct = 0;
-            for (int i = 0; i < prob.l; i++)
+            for (int i = 0; i < prob.getL(); i++)
                 if (target[i] == prob.y[i])
                     ++total_correct;
 
             System.out.printf("correct: %d%n", total_correct);
-            System.out.printf("Cross Validation Accuracy = %g%%%n", 100.0 * total_correct / prob.l);
+            System.out.printf("Cross Validation Accuracy = %g%%%n", 100.0 * total_correct / prob.getL());
         }
     }
 
@@ -287,8 +290,10 @@ public class Train {
      * @throws InvalidInputDataException if the input file is not correctly formatted
      * @deprecated use {@link Train#readProblem(Path, double)} instead
      */
-    public static Problem readProblem(File file, double bias) throws IOException, InvalidInputDataException {
-        return readProblem(file.toPath(), bias);
+    public static Problem readProblem(Class<? extends ArrayList<FeatureVector>> clazz,
+                                      File file, double bias)
+          throws IOException, InvalidInputDataException, InstantiationException, IllegalAccessException {
+        return readProblem(clazz, file.toPath(), bias);
     }
 
     /**
@@ -296,30 +301,44 @@ public class Train {
      * @throws IOException obviously in case of any I/O exception ;)
      * @throws InvalidInputDataException if the input file is not correctly formatted
      */
-    public static Problem readProblem(Path path, double bias) throws IOException, InvalidInputDataException {
+    public static Problem<? extends ArrayList<FeatureVector>> readProblem(Class<? extends ArrayList<FeatureVector>> clazz,
+                                      Path path, double bias)
+          throws IOException, InvalidInputDataException, IllegalAccessException, InstantiationException {
         try (InputStream inputStream = Files.newInputStream(path)) {
-            return readProblem(inputStream, bias);
+            return readProblem(clazz,inputStream, bias);
         }
     }
 
     /**
      * @deprecated use {@link Train#readProblem(Path, Charset, double)} instead
      */
-    public static Problem readProblem(File file, Charset charset, double bias) throws IOException, InvalidInputDataException {
-        return readProblem(file.toPath(), charset, bias);
+    public static Problem<? extends ArrayList<FeatureVector>> readProblem(Class<? extends ArrayList<FeatureVector>> clazz,
+                                      File file, Charset charset,
+                                      double bias)
+          throws IOException, InvalidInputDataException, IllegalAccessException, InstantiationException {
+        return readProblem(clazz, file.toPath(), charset, bias);
     }
 
-    public static Problem readProblem(Path path, Charset charset, double bias) throws IOException, InvalidInputDataException {
+    public static Problem<? extends ArrayList<FeatureVector>> readProblem(Class<? extends ArrayList<FeatureVector>> clazz,
+                                      Path path, Charset charset,
+                                      double bias)
+          throws IOException, InvalidInputDataException, InstantiationException, IllegalAccessException {
         try (InputStream inputStream = Files.newInputStream(path)) {
-            return readProblem(inputStream, charset, bias);
+            return readProblem(clazz, inputStream, charset, bias);
         }
     }
 
-    public static Problem readProblem(InputStream inputStream, double bias) throws IOException, InvalidInputDataException {
-        return readProblem(inputStream, Charset.defaultCharset(), bias);
+    public static Problem<? extends ArrayList<FeatureVector>> readProblem(Class<? extends ArrayList<FeatureVector>> clazz,
+                                      InputStream inputStream,
+                                      double bias)
+          throws IOException, InvalidInputDataException, InstantiationException, IllegalAccessException {
+        return readProblem(clazz, inputStream, Charset.defaultCharset(), bias);
     }
 
-    public static Problem readProblem(InputStream inputStream, Charset charset, double bias) throws IOException, InvalidInputDataException {
+    public static Problem<? extends ArrayList<FeatureVector>> readProblem(Class<? extends ArrayList<FeatureVector>> clazz,
+                                      InputStream inputStream,
+                                      Charset charset, double bias)
+          throws IOException, InvalidInputDataException, IllegalAccessException, InstantiationException {
         BufferedReader fp = new BufferedReader(new InputStreamReader(inputStream, charset));
         List<Double> vy = new ArrayList<>();
         List<Feature[]> vx = new ArrayList<>();
@@ -387,19 +406,22 @@ public class Train {
             vx.add(x);
         }
 
-        return constructProblem(vy, vx, max_index, bias);
+        return constructProblem(clazz, vy, vx, max_index, bias);
     }
 
-    public void readProblem(Path path) throws IOException, InvalidInputDataException {
-        prob = Train.readProblem(path, bias);
+    public void readProblem(Class<? extends ArrayList<FeatureVector>> clazz, Path path) throws IOException,
+          InvalidInputDataException, InstantiationException, IllegalAccessException {
+        prob = Train.readProblem(clazz, path, bias);
     }
 
-    public void readProblem(String filename) throws IOException, InvalidInputDataException {
-        readProblem(filename, bias);
+    public void readProblem(Class<? extends ArrayList<FeatureVector>> clazz, String filename) throws IOException,
+          InvalidInputDataException, IllegalAccessException, InstantiationException {
+        readProblem(clazz, filename, bias);
     }
 
-    public void readProblem(String filename, double bias) throws IOException, InvalidInputDataException {
-        prob = Train.readProblem(Paths.get(filename), bias);
+    public void readProblem(Class<? extends ArrayList<FeatureVector>> clazz, String filename, double bias)
+          throws IOException, InvalidInputDataException, InstantiationException, IllegalAccessException {
+        prob = Train.readProblem(clazz, Paths.get(filename), bias);
     }
 
     private static int[] addToArray(int[] array, int newElement) {
@@ -422,34 +444,38 @@ public class Train {
         return newArray;
     }
 
-    private static Problem constructProblem(List<Double> vy, List<Feature[]> vx, int max_index, double bias) {
-        Problem prob = new Problem();
+    private static Problem<? extends ArrayList<FeatureVector>> constructProblem(Class<? extends ArrayList<FeatureVector>> clazz,
+                                            List<Double> vy,
+                                            List<Feature[]> vx, int max_index, double bias)
+          throws InstantiationException, IllegalAccessException {
+        Problem<? extends ArrayList<FeatureVector>> prob = new Problem<>(clazz, vy.size());
         prob.bias = bias;
-        prob.l = vy.size();
         prob.n = max_index;
+        prob.setL(vy.size());
         if (bias >= 0) {
             prob.n++;
         }
-        prob.x = new Feature[prob.l][];
-        for (int i = 0; i < prob.l; i++) {
-            prob.x[i] = vx.get(i);
+        for (int i = 0; i < prob.getL(); i++) {
+            prob.setX(i,vx.get(i));
 
             if (bias >= 0) {
-                assert prob.x[i][prob.x[i].length - 1] == null;
-                prob.x[i][prob.x[i].length - 1] = new FeatureNode(max_index + 1, bias);
+                assert prob.getX(i)[prob.getX(i).length - 1] == null;
+                prob.getX(i)[prob.getX(i).length - 1] = new FeatureNode(max_index + 1, bias);
             }
         }
 
-        prob.y = new double[prob.l];
-        for (int i = 0; i < prob.l; i++)
+        prob.y = new double[prob.getL()];
+        for (int i = 0; i < prob.getL(); i++)
             prob.y[i] = vy.get(i).doubleValue();
 
         return prob;
     }
 
-    private void run(String[] args) throws IOException, InvalidInputDataException {
+    private void run(String[] args)
+          throws IOException, InvalidInputDataException, InstantiationException, IllegalAccessException {
         parse_command_line(args);
-        readProblem(inputFilename);
+        Class clazz = ArrayList.class;
+        readProblem(clazz, inputFilename);
         if (find_parameters) {
             do_find_parameters();
         } else if (cross_validation)

--- a/src/test/java/de/bwaldvogel/liblinear/TrainTest.java
+++ b/src/test/java/de/bwaldvogel/liblinear/TrainTest.java
@@ -1,26 +1,24 @@
 package de.bwaldvogel.liblinear;
 
-import static de.bwaldvogel.liblinear.SolverType.*;
-import static de.bwaldvogel.liblinear.TestUtils.*;
-import static org.assertj.core.api.Assertions.*;
+import static de.bwaldvogel.liblinear.SolverType.L2R_L2LOSS_SVC;
+import static de.bwaldvogel.liblinear.SolverType.L2R_LR;
+import static de.bwaldvogel.liblinear.TestUtils.writeToFile;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 
 class TrainTest {
-    private static Class clazz = ArrayList.class;
-
     @BeforeEach
     public void reset() throws Exception {
         Linear.resetRandom();
@@ -33,23 +31,23 @@ class TrainTest {
             if (solver.isOneClass()) {
                 continue;
             }
-            Train.main(new String[] {"-v", "5", "-s", "" + solver.getId(), "src/test/resources/iris.scale"});
+            Train.main(new String[]{"-v", "5", "-s", "" + solver.getId(), "src/test/resources/iris.scale"});
         }
     }
 
     @Test
     void testFindBestCOnIrisDataSet() throws Exception {
-        Train.main(new String[] {"-C", "src/test/resources/iris.scale"});
+        Train.main(new String[]{"-C", "src/test/resources/iris.scale"});
     }
 
     @Test
     void testFindBestCOnIrisDataSet_L2R_L2LOSS_SVR_DUAL() throws Exception {
-        Train.main(new String[] {"-s", "11", "-C", "src/test/resources/iris.scale"});
+        Train.main(new String[]{"-s", "11", "-C", "src/test/resources/iris.scale"});
     }
 
     @Test
     void testFindBestCOnSpliceDataSet_L2R_L2LOSS_SVR_DUAL() throws Exception {
-        Train.main(new String[] {"-s", "11", "-C", "src/test/datasets/splice/splice"});
+        Train.main(new String[]{"-s", "11", "-C", "src/test/datasets/splice/splice"});
     }
 
     @Test
@@ -57,7 +55,8 @@ class TrainTest {
         Train train = new Train();
 
         for (SolverType solver : SolverType.values()) {
-            train.parse_command_line(new String[] {"-B", "5.3", "-s", "" + solver.getId(), "-p", "0.01", "model-filename"});
+            train.parse_command_line(
+                  new String[]{"-B", "5.3", "-s", "" + solver.getId(), "-p", "0.01", "model-filename"});
             assertThat(train.isFindParameters()).isFalse();
             assertThat(train.getNumFolds()).isEqualTo(0);
             Parameter param = train.getParameter();
@@ -69,8 +68,8 @@ class TrainTest {
             } else if (solver.getId() == 7) {
                 assertThat(param.eps).isEqualTo(0.1);
             } else if (solver.getId() == 11) {
-                assertThat(param.eps).isEqualTo(0.0001);}
-            else if (solver.getId() == 21) {
+                assertThat(param.eps).isEqualTo(0.0001);
+            } else if (solver.getId() == 21) {
                 assertThat(param.eps).isEqualTo(0.01);
             } else {
                 assertThat(param.eps).isEqualTo(0.1);
@@ -85,7 +84,7 @@ class TrainTest {
     void testParseCommandLine_FindC_NoSolverSpecified() {
         Train train = new Train();
 
-        train.parse_command_line(new String[] {"-C", "model-filename"});
+        train.parse_command_line(new String[]{"-C", "model-filename"});
         assertThat(train.isFindParameters()).isTrue();
         assertThat(train.getNumFolds()).isEqualTo(5);
         Parameter param = train.getParameter();
@@ -99,7 +98,7 @@ class TrainTest {
     void testParseCommandLine_FindC_SolverAndNumFoldsSpecified() {
         Train train = new Train();
 
-        train.parse_command_line(new String[] {"-s", "0", "-v", "10", "-C", "model-filename"});
+        train.parse_command_line(new String[]{"-s", "0", "-v", "10", "-C", "model-filename"});
         assertThat(train.isFindParameters()).isTrue();
         assertThat(train.getNumFolds()).isEqualTo(10);
         Parameter param = train.getParameter();
@@ -109,28 +108,28 @@ class TrainTest {
     }
 
     @Test
-    // https://github.com/bwaldvogel/liblinear-java/issues/4
+        // https://github.com/bwaldvogel/liblinear-java/issues/4
     void testParseWeights() throws Exception {
         Train train = new Train();
-        train.parse_command_line(new String[] {"-v", "10", "-c", "10", "-w1", "1.234", "model-filename"});
+        train.parse_command_line(new String[]{"-v", "10", "-c", "10", "-w1", "1.234", "model-filename"});
         Parameter parameter = train.getParameter();
-        assertThat(parameter.weightLabel).isEqualTo(new int[] {1});
-        assertThat(parameter.weight).isEqualTo(new double[] {1.234});
+        assertThat(parameter.weightLabel).isEqualTo(new int[]{1});
+        assertThat(parameter.weight).isEqualTo(new double[]{1.234});
 
-        train.parse_command_line(new String[] {"-w1", "1.234", "-w2", "0.12", "-w3", "7", "model-filename"});
+        train.parse_command_line(new String[]{"-w1", "1.234", "-w2", "0.12", "-w3", "7", "model-filename"});
         parameter = train.getParameter();
-        assertThat(parameter.weightLabel).isEqualTo(new int[] {1, 2, 3});
-        assertThat(parameter.weight).isEqualTo(new double[] {1.234, 0.12, 7});
+        assertThat(parameter.weightLabel).isEqualTo(new int[]{1, 2, 3});
+        assertThat(parameter.weight).isEqualTo(new double[]{1.234, 0.12, 7});
     }
 
     @Test
     void testParseCommandLine_regularizeBias() throws Exception {
         Train train = new Train();
-        train.parse_command_line(new String[] {"-R", "model-filename"});
+        train.parse_command_line(new String[]{"-R", "model-filename"});
         Parameter parameter = train.getParameter();
         assertThat(parameter.regularize_bias).isFalse();
 
-        train.parse_command_line(new String[] {"model-filename"});
+        train.parse_command_line(new String[]{"model-filename"});
         parameter = train.getParameter();
         assertThat(parameter.regularize_bias).isTrue();
     }
@@ -140,42 +139,44 @@ class TrainTest {
         Path problemPath = tempDir.resolve("problem");
 
         List<String> lines = Arrays.asList(
-            "1 1:1  3:1  4:1   6:1",
-            "2 2:1  3:1  5:1   7:1",
-            "1 3:1  5:1",
-            "1 1:1  4:1  7:1",
-            "2 4:1  5:1  7:1");
+              "1 1:1  3:1  4:1   6:1",
+              "2 2:1  3:1  5:1   7:1",
+              "1 3:1  5:1",
+              "1 1:1  4:1  7:1",
+              "2 4:1  5:1  7:1");
 
         writeToFile(problemPath, lines);
 
         Train train = new Train();
-        train.readProblem(clazz, problemPath);
+        train.readProblem(new MemoryListFactory(), problemPath);
 
-        Problem prob = train.getProblem();
-        assertThat(prob.bias).isEqualTo(1);
-        assertThat(prob.y).hasSize(lines.size());
-        assertThat(prob.y).isEqualTo(new double[] {1, 2, 1, 1, 2});
-        assertThat(prob.n).isEqualTo(8);
-        assertThat(prob.getL()).isEqualTo(prob.y.length);
-        //TODO: fix
-        //assertThat(prob.x.length).isEqualTo(prob.y.length);
+        try (Problem prob = train.getProblem()) {
+            assertThat(prob.bias).isEqualTo(1);
+            assertThat(prob.y).hasSize(lines.size());
+            assertThat(prob.y).isEqualTo(new double[]{1, 2, 1, 1, 2});
+            assertThat(prob.n).isEqualTo(8);
+            assertThat(prob.getL()).isEqualTo(prob.y.length);
+            //TODO: fix
+            //assertThat(prob.x.length).isEqualTo(prob.y.length);
 
-        validate(prob);
+            validate(prob);
+        }
     }
 
     @Test
     void testReadProblemFromStream() throws Exception {
         String data = "1 1:1  3:1  4:1   6:1\n"
-            + "2 2:1  3:1  5:1   7:1\n"
-            + "1 3:1  5:1\n"
-            + "1 1:1  4:1  7:1\n"
-            + "2 4:1  5:1  7:1\n";
+                      + "2 2:1  3:1  5:1   7:1\n"
+                      + "1 3:1  5:1\n"
+                      + "1 1:1  4:1  7:1\n"
+                      + "2 4:1  5:1  7:1\n";
 
         Charset charset = StandardCharsets.UTF_8;
-        Problem prob = Train.readProblem(clazz, new ByteArrayInputStream(data.getBytes(charset)), charset, 1);
+        Problem prob = Train
+              .readProblem(new MemoryListFactory(), new ByteArrayInputStream(data.getBytes(charset)), charset, 1);
         assertThat(prob.bias).isEqualTo(1);
         assertThat(prob.y).hasSize(5);
-        assertThat(prob.y).isEqualTo(new double[] {1, 2, 1, 1, 2});
+        assertThat(prob.y).isEqualTo(new double[]{1, 2, 1, 1, 2});
         assertThat(prob.n).isEqualTo(8);
         assertThat(prob.getL()).isEqualTo(prob.y.length);
         //TODO: fix
@@ -192,15 +193,15 @@ class TrainTest {
         Path file = tempDir.resolve("problem");
 
         List<String> lines = Arrays.asList(
-            "1 1:1  3:1  4:1   6:1",
-            "2 ");
+              "1 1:1  3:1  4:1   6:1",
+              "2 ");
 
         writeToFile(file, lines);
 
-        Problem prob = Train.readProblem(clazz, file, -1.0);
+        Problem prob = Train.readProblem(new MemoryListFactory(), file, -1.0);
         assertThat(prob.bias).isEqualTo(-1);
         assertThat(prob.y).hasSize(lines.size());
-        assertThat(prob.y).isEqualTo(new double[] {1, 2});
+        assertThat(prob.y).isEqualTo(new double[]{1, 2});
         assertThat(prob.n).isEqualTo(6);
         assertThat(prob.getL()).isEqualTo(prob.y.length);
         //TODO: fix
@@ -215,17 +216,17 @@ class TrainTest {
         Path file = tempDir.resolve("problem");
 
         List<String> lines = Arrays.asList(
-            "1 1:1  3:1  4:1   6:1",
-            "2 2:1  3:1  5:1   7:1",
-            "1 3:1  5:1  4:1"); // here's the mistake: not correctly sorted
+              "1 1:1  3:1  4:1   6:1",
+              "2 2:1  3:1  5:1   7:1",
+              "1 3:1  5:1  4:1"); // here's the mistake: not correctly sorted
 
         writeToFile(file, lines);
 
         Train train = new Train();
 
         assertThatExceptionOfType(InvalidInputDataException.class)
-            .isThrownBy(() -> train.readProblem(clazz, file))
-            .withMessage("indices must be sorted in ascending order");
+              .isThrownBy(() -> train.readProblem(new MemoryListFactory(), file))
+              .withMessage("indices must be sorted in ascending order");
     }
 
     @Test
@@ -233,16 +234,16 @@ class TrainTest {
         Path file = tempDir.resolve("problem");
 
         List<String> lines = Arrays.asList(
-            "1 1:1  3:1  4:1   6:1",
-            "2 2:1  3:1  5:1  -4:1");
+              "1 1:1  3:1  4:1   6:1",
+              "2 2:1  3:1  5:1  -4:1");
 
         writeToFile(file, lines);
 
         Train train = new Train();
 
         assertThatExceptionOfType(InvalidInputDataException.class)
-            .isThrownBy(() -> train.readProblem(clazz, file))
-            .withMessage("invalid index: -4");
+              .isThrownBy(() -> train.readProblem(new MemoryListFactory(), file))
+              .withMessage("invalid index: -4");
     }
 
     @Test
@@ -256,8 +257,8 @@ class TrainTest {
         Train train = new Train();
 
         assertThatExceptionOfType(InvalidInputDataException.class)
-            .isThrownBy(() -> train.readProblem(clazz, file))
-            .withMessage("invalid index: 0");
+              .isThrownBy(() -> train.readProblem(new MapDbOffHeapListFactory(), file))
+              .withMessage("invalid index: 0");
     }
 
     @Test
@@ -265,21 +266,21 @@ class TrainTest {
         Path file = tempDir.resolve("problem");
 
         List<String> lines = Arrays.asList(
-            "1 1:1  3:1  4:1   6:1",
-            "2 2:1  3:1  5:1   7:1",
-            "1 3:1  5:a"); // here's the mistake: incomplete line
+              "1 1:1  3:1  4:1   6:1",
+              "2 2:1  3:1  5:1   7:1",
+              "1 3:1  5:a"); // here's the mistake: incomplete line
 
         writeToFile(file, lines);
 
         Train train = new Train();
 
         assertThatExceptionOfType(InvalidInputDataException.class)
-            .isThrownBy(() -> train.readProblem(clazz, file))
-            .withMessage("invalid value: a");
+              .isThrownBy(() -> train.readProblem(new MapDbFileListFactory(), file))
+              .withMessage("invalid value: a");
     }
 
-    private void validate(Problem<? extends ArrayList<FeatureVector>> prob) {
-        prob.getXIterator().forEachRemaining(vector->{
+    private void validate(Problem<? extends ListFactory> prob) {
+        prob.getXIterator().forEachRemaining(vector -> {
             Feature[] nodes = vector.getFeatures();
             assertThat(nodes.length).isLessThanOrEqualTo(prob.n);
             for (Feature node : nodes) {


### PR DESCRIPTION
- the original version holds the whole feature set in arrays
- this quickly runs out of memory during cross-validation when multiple sub-problems are generated
- added a list factory which can be extended to provide array lists backed by different sources (memory, file, off-heap etc.)
- added MapDb to off-heap and file-based lists
- cleaned up some direct access of member variables